### PR TITLE
fix: Fix tax rounding issue in update_itemised_tax_data

### DIFF
--- a/ksa_compliance/utils/update_itemised_tax_data.py
+++ b/ksa_compliance/utils/update_itemised_tax_data.py
@@ -60,10 +60,11 @@ def update_itemised_tax_data(doc):
                     net_from_gross = calculate_net_from_gross_included_in_print_rate(
                         amount, _tax_rate
                     )
-                    tax_amount += flt(
-                        calculate_tax_amount_included_in_print_rate(amount, net_from_gross),
-                        row.precision("tax_amount"),
-                    )
+                    # Fix: Round net_amount first, then calculate tax from rounded net_amount
+                    # This matches the calculation in taxes_and_totals.py to avoid rounding differences
+                    net_rounded = flt(net_from_gross, row.precision("net_amount"))
+                    tax_from_net = (net_rounded * _tax_rate) / 100
+                    tax_amount += flt(tax_from_net, row.precision("tax_amount"))
                 else:
                     tax_amount += flt(
                         (row.net_amount * _tax_rate) / 100, row.precision("tax_amount")


### PR DESCRIPTION
- Changed tax calculation method to match ERPNext's taxes_and_totals.py
- Now rounds net_amount first, then calculates tax from rounded value
- This prevents 0.01 rounding difference between items tax_amount and total_taxes_and_charges
- Ensures consistency with ZATCA XML generation

Before: tax = gross - net (causes rounding difference)
After: tax = rounded_net * rate (matches ERPNext calculation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved precision in itemized tax data calculations through refined rounding methodology for tax amount computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->