### PR TITLE
fix: default argument is evaluated once at import time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+## 0.68.4
+* Fix default argument is evaluated once at import time
+
 ## 0.68.3
 * Fix function get_itemised_tax changes on v16
 * Fix none values on einvoice details

--- a/ksa_compliance/__init__.py
+++ b/ksa_compliance/__init__.py
@@ -17,4 +17,4 @@ except (FileNotFoundError, OSError):
         logger.addHandler(handler)
 
 
-__version__ = "0.68.3"
+__version__ = "0.68.4"

--- a/ksa_compliance/background_jobs.py
+++ b/ksa_compliance/background_jobs.py
@@ -14,9 +14,11 @@ from ksa_compliance.ksa_compliance.doctype.sales_invoice_additional_fields.sales
 
 
 @frappe.whitelist()
-def add_batch_to_background_queue(check_date: datetime.date = datetime.date.today()):
+def add_batch_to_background_queue(check_date: datetime.date | None = None):
     try:
         logger.info("Start Enqueue E-Invoices")
+        if check_date is None:
+            check_date = datetime.date.today()
         frappe_version = int(frappe.__version__.split(".")[0])
 
         enqueue_kwargs = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed background job queue to use the current date when enqueued, rather than the date the module was initially imported.

* **Chores**
  * Version bumped to 0.68.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->