### PR TITLE
fix: select a non-group Customer Group on create customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+## 0.68.5
+* Fix select a non-group Customer Group on create customer
+
 ## 0.68.4
 * Fix default argument is evaluated once at import time
 

--- a/ksa_compliance/__init__.py
+++ b/ksa_compliance/__init__.py
@@ -17,4 +17,4 @@ except (FileNotFoundError, OSError):
         logger.addHandler(handler)
 
 
-__version__ = "0.68.4"
+__version__ = "0.68.5"

--- a/ksa_compliance/ksa_compliance/test/ksa_compliance_test_base.py
+++ b/ksa_compliance/ksa_compliance/test/ksa_compliance_test_base.py
@@ -40,7 +40,7 @@ class KSAComplianceTestBase(FrappeTestCase):
             customer = frappe.new_doc("Customer")
             customer.customer_name = TEST_STANDARD_CUSTOMER_NAME
             customer.customer_type = "Individual"
-            customer.customer_group = "All Customer Groups"
+            customer.customer_group = "Individual"
             customer.territory = "All Territories"
             customer.insert(ignore_permissions=True)
 
@@ -49,7 +49,7 @@ class KSAComplianceTestBase(FrappeTestCase):
             customer = frappe.new_doc("Customer")
             customer.customer_name = TEST_SIMPLIFIED_CUSTOMER_NAME
             customer.customer_type = "Individual"
-            customer.customer_group = "All Customer Groups"
+            customer.customer_group = "Individual"
             customer.territory = "All Territories"
             customer.insert(ignore_permissions=True)
 

--- a/ksa_compliance/ksa_compliance/test/ksa_compliance_test_base.py
+++ b/ksa_compliance/ksa_compliance/test/ksa_compliance_test_base.py
@@ -40,7 +40,7 @@ class KSAComplianceTestBase(FrappeTestCase):
             customer = frappe.new_doc("Customer")
             customer.customer_name = TEST_STANDARD_CUSTOMER_NAME
             customer.customer_type = "Individual"
-            customer.customer_group = "Individual"
+            customer.customer_group = "Company"
             customer.territory = "All Territories"
             customer.insert(ignore_permissions=True)
 

--- a/ksa_compliance/test/test_setup.py
+++ b/ksa_compliance/test/test_setup.py
@@ -109,7 +109,7 @@ def _create_standard_customer(customer_name, tax_category_name=None, with_addres
             "doctype": "Customer",
             "customer_name": customer_name,
             "customer_type": "Company",
-            "customer_group": "All Customer Groups",
+            "customer_group": "Individual",
             "territory": "All Territories",
             "tax_id": "311609596400003",
             "custom_vat_registration_number": "311609596400003",
@@ -130,7 +130,7 @@ def _create_simplified_customer():
             "doctype": "Customer",
             "customer_name": TEST_SIMPLIFIED_CUSTOMER_NAME,
             "customer_type": "Individual",
-            "customer_group": "All Customer Groups",
+            "customer_group": "Individual",
             "territory": "All Territories",
         })
         customer_doc.insert(ignore_permissions=True)

--- a/ksa_compliance/test/test_setup.py
+++ b/ksa_compliance/test/test_setup.py
@@ -109,7 +109,7 @@ def _create_standard_customer(customer_name, tax_category_name=None, with_addres
             "doctype": "Customer",
             "customer_name": customer_name,
             "customer_type": "Company",
-            "customer_group": "Individual",
+            "customer_group": "Company",
             "territory": "All Territories",
             "tax_id": "311609596400003",
             "custom_vat_registration_number": "311609596400003",


### PR DESCRIPTION
https://tasko.rukn.sh/tasko/task/TASK-2026-00472
https://github.com/frappe/erpnext/blob/version-15/erpnext/selling/doctype/customer/customer.py#L335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where non-group Customer Groups could not be selected during customer creation.

* **Chores**
  * Bumped version to 0.68.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->