### PR TITLE
fix: check is enabled ZATCA Business Settings for company on before Add Phase 1 Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+## 0.69.2
+* fix check is enabled ZATCA Business Settings for company on before Add Phase 1 Settings
+
 ## 0.69.1
 * Complete decoupling from POS Invoice to ensure consistency between printed and submitted invoices.
 * Fix avoid prepayment return on POS Invoice 

--- a/ksa_compliance/__init__.py
+++ b/ksa_compliance/__init__.py
@@ -17,4 +17,4 @@ except (FileNotFoundError, OSError):
         logger.addHandler(handler)
 
 
-__version__ = "0.69.1"
+__version__ = "0.69.2"

--- a/ksa_compliance/ksa_compliance/doctype/zatca_phase_1_business_settings/zatca_phase_1_business_settings.py
+++ b/ksa_compliance/ksa_compliance/doctype/zatca_phase_1_business_settings/zatca_phase_1_business_settings.py
@@ -34,10 +34,7 @@ class ZATCAPhase1BusinessSettings(Document):
                 business_settings_doc = frappe.get_doc(
                     "ZATCA Business Settings", business_settings_id
                 )
-                if (
-                    business_settings_doc.enable_zatca_integration
-                    or business_settings_doc.has_production_csid
-                ):
+                if business_settings_doc.is_enabled_for_company(self.company):
                     link = get_link_to_form("ZATCA Business Settings", business_settings_id)
                     frappe.throw(
                         _(


### PR DESCRIPTION
https://tasko.rukn.sh/tasko/task/TASK-2026-00484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to correctly check if a ZATCA Business Settings configuration is already enabled for the company before allowing Phase 1 settings to be added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruknsoftware/rukn-zatca-connector/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->