### PR TITLE
fix: create sales invoice with withdrawn phase 2 and Active phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ to a section with the version name.
 
 ## Unreleased Changes
 
+## 0.69.3
+* Fix create sales invoice with withdrawn phase 2 and Active phase 1
+
 ## 0.69.2
 * fix check is enabled ZATCA Business Settings for company on before Add Phase 1 Settings
 

--- a/ksa_compliance/__init__.py
+++ b/ksa_compliance/__init__.py
@@ -17,4 +17,4 @@ except (FileNotFoundError, OSError):
         logger.addHandler(handler)
 
 
-__version__ = "0.69.2"
+__version__ = "0.69.3"

--- a/ksa_compliance/standard_doctypes/sales_invoice.py
+++ b/ksa_compliance/standard_doctypes/sales_invoice.py
@@ -72,7 +72,9 @@ def create_sales_invoice_additional_fields_doctype(
 ):
     settings = ZATCABusinessSettings.for_invoice(self.name, self.doctype)
     if not settings:
-        if ZATCABusinessSettings.is_withdrawn_for_company(self.company):
+        if ZATCABusinessSettings.is_withdrawn_for_company(
+            self.company
+        ) and not ZATCAPhase1BusinessSettings.is_enabled_for_company(self.company):
             fthrow(msg=ft("Cannot submit sales invoice to ZATCA"), title=ft("CSID Is Withdrawn"))
         logger.info(
             f"Skipping additional fields for {self.name} because of missing ZATCA settings"


### PR DESCRIPTION
https://tasko.rukn.sh/tasko/task/TASK-2026-00497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with creating sales invoices when Phase 2 is withdrawn and Phase 1 is active, allowing the submission of additional invoice fields to ZATCA in this scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruknsoftware/rukn-zatca-connector/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->